### PR TITLE
Fix focus on tab change

### DIFF
--- a/components/tabs/Tabs.js
+++ b/components/tabs/Tabs.js
@@ -98,11 +98,16 @@ const factory = (Tab, TabContent, FontIcon) => {
       }
 
       const charCode = event.which || event.keyCode;
-      if (charCode === KEYS.LEFT_ARROW) {
-        this.handleHeaderSelect(mod(this.props.index - 1, this.props.children.length));
-      }
-      if (charCode === KEYS.RIGHT_ARROW) {
-        this.handleHeaderSelect(mod(this.props.index + 1, this.props.children.length));
+      if (charCode === KEYS.LEFT_ARROW || charCode === KEYS.RIGHT_ARROW) {
+        const idx = charCode === KEYS.LEFT_ARROW ?
+          mod(this.props.index - 1, this.props.children.length) :
+          mod(this.props.index + 1, this.props.children.length);
+
+        this.handleHeaderSelect(idx);
+        const tabNode = this.navigationNode && this.navigationNode.children[idx];
+        if (tabNode) {
+          tabNode.focus();
+        }
       }
     }
 

--- a/lib/tabs/Tabs.js
+++ b/lib/tabs/Tabs.js
@@ -100,11 +100,14 @@ var factory = function factory(Tab, TabContent, FontIcon) {
         }
 
         var charCode = event.which || event.keyCode;
-        if (charCode === _keymap2.default.LEFT_ARROW) {
-          _this.handleHeaderSelect((0, _utils.mod)(_this.props.index - 1, _this.props.children.length));
-        }
-        if (charCode === _keymap2.default.RIGHT_ARROW) {
-          _this.handleHeaderSelect((0, _utils.mod)(_this.props.index + 1, _this.props.children.length));
+        if (charCode === _keymap2.default.LEFT_ARROW || charCode === _keymap2.default.RIGHT_ARROW) {
+          var idx = charCode === _keymap2.default.LEFT_ARROW ? (0, _utils.mod)(_this.props.index - 1, _this.props.children.length) : (0, _utils.mod)(_this.props.index + 1, _this.props.children.length);
+
+          _this.handleHeaderSelect(idx);
+          var tabNode = _this.navigationNode && _this.navigationNode.children[idx];
+          if (tabNode) {
+            tabNode.focus();
+          }
         }
       }, _this.updatePointer = function (idx) {
         if (_this.navigationNode && _this.navigationNode.children[idx]) {


### PR DESCRIPTION
Reason: if you first click on a tab and then move to another
by pressing left/right key, you'll notice the tab you clicked
keep focus, and therefore you see two brighter tabs